### PR TITLE
Add games and quiz fragments with mini-games

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AppCompat.Light.DarkActionBar">
         <activity
+            android:name=".games.TapGameActivity" />
+        <activity
+            android:name=".games.TicTacToeActivity" />
+        <activity
             android:name=".MainActivity"
             android:exported="true"
             android:theme="@style/Theme.AppCompat.Light.DarkActionBar">

--- a/app/src/main/java/com/motus/cricketverse/GamesFragment.kt
+++ b/app/src/main/java/com/motus/cricketverse/GamesFragment.kt
@@ -1,0 +1,31 @@
+package com.motus.cricketverse
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import com.motus.cricketverse.games.TapGameActivity
+import com.motus.cricketverse.games.TicTacToeActivity
+
+class GamesFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_games, container, false)
+
+        view.findViewById<Button>(R.id.btnTapGame).setOnClickListener {
+            startActivity(Intent(requireContext(), TapGameActivity::class.java))
+        }
+        view.findViewById<Button>(R.id.btnTicTacToe).setOnClickListener {
+            startActivity(Intent(requireContext(), TicTacToeActivity::class.java))
+        }
+        return view
+    }
+}
+

--- a/app/src/main/java/com/motus/cricketverse/MainActivity.kt
+++ b/app/src/main/java/com/motus/cricketverse/MainActivity.kt
@@ -4,6 +4,8 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.motus.cricketverse.ScoreFragment
+import com.motus.cricketverse.GamesFragment
+import com.motus.cricketverse.QuizFragment
 class MainActivity : AppCompatActivity() {
 
     private lateinit var bottomNavigationView: BottomNavigationView
@@ -17,11 +19,15 @@ class MainActivity : AppCompatActivity() {
         loadFragment(MatchesFragment()) // Default tab
 
         bottomNavigationView.setOnItemSelectedListener { item ->
-            when (item.itemId) {
-                R.id.nav_matches -> loadFragment(MatchesFragment())
-                R.id.nav_scores -> loadFragment(ScoreFragment())
-                R.id.nav_profile -> loadFragment(ProfileFragment())
+            val fragment: Fragment = when (item.itemId) {
+                R.id.nav_matches -> MatchesFragment()
+                R.id.nav_scores -> ScoreFragment()
+                R.id.nav_games -> GamesFragment()
+                R.id.nav_quiz -> QuizFragment()
+                R.id.nav_profile -> ProfileFragment()
+                else -> MatchesFragment()
             }
+            loadFragment(fragment)
             true
         }
     }

--- a/app/src/main/java/com/motus/cricketverse/QuizFragment.kt
+++ b/app/src/main/java/com/motus/cricketverse/QuizFragment.kt
@@ -1,0 +1,19 @@
+package com.motus.cricketverse
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class QuizFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_quiz, container, false)
+    }
+}
+

--- a/app/src/main/java/com/motus/cricketverse/games/TapGameActivity.kt
+++ b/app/src/main/java/com/motus/cricketverse/games/TapGameActivity.kt
@@ -1,0 +1,47 @@
+package com.motus.cricketverse.games
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.motus.cricketverse.R
+
+class TapGameActivity : AppCompatActivity() {
+
+    private lateinit var tapButton: Button
+    private lateinit var scoreText: TextView
+    private var score = 0
+    private val handler = Handler(Looper.getMainLooper())
+    private var timeLeft = 30
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_tap_game)
+
+        tapButton = findViewById(R.id.tapButton)
+        scoreText = findViewById(R.id.scoreText)
+
+        tapButton.setOnClickListener {
+            score++
+            scoreText.text = getString(R.string.score_value, score, timeLeft)
+        }
+        startTimer()
+    }
+
+    private fun startTimer() {
+        handler.post(object : Runnable {
+            override fun run() {
+                if (timeLeft > 0) {
+                    timeLeft--
+                    scoreText.text = getString(R.string.score_value, score, timeLeft)
+                    handler.postDelayed(this, 1000)
+                } else {
+                    tapButton.isEnabled = false
+                }
+            }
+        })
+    }
+}
+

--- a/app/src/main/java/com/motus/cricketverse/games/TicTacToeActivity.kt
+++ b/app/src/main/java/com/motus/cricketverse/games/TicTacToeActivity.kt
@@ -1,0 +1,75 @@
+package com.motus.cricketverse.games
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.GridLayout
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import com.motus.cricketverse.R
+
+class TicTacToeActivity : AppCompatActivity() {
+
+    private lateinit var statusText: TextView
+    private lateinit var gridLayout: GridLayout
+    private var board = Array(3) { Array(3) { "" } }
+    private var currentPlayer = "X"
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_tic_tac_toe)
+
+        statusText = findViewById(R.id.statusText)
+        gridLayout = findViewById(R.id.gridLayout)
+
+        for (i in 0 until gridLayout.childCount) {
+            val button = gridLayout.getChildAt(i) as Button
+            val row = i / 3
+            val col = i % 3
+            button.setOnClickListener { onCellClicked(button, row, col) }
+        }
+        updateStatus()
+    }
+
+    private fun onCellClicked(button: Button, row: Int, col: Int) {
+        if (board[row][col].isNotEmpty()) return
+        board[row][col] = currentPlayer
+        button.text = currentPlayer
+        if (checkWin()) {
+            statusText.text = getString(R.string.winner_text, currentPlayer)
+            disableBoard()
+        } else if (isBoardFull()) {
+            statusText.text = getString(R.string.draw_text)
+        } else {
+            currentPlayer = if (currentPlayer == "X") "O" else "X"
+            updateStatus()
+        }
+    }
+
+    private fun checkWin(): Boolean {
+        for (i in 0..2) {
+            if (board[i][0] == currentPlayer && board[i][1] == currentPlayer && board[i][2] == currentPlayer) return true
+            if (board[0][i] == currentPlayer && board[1][i] == currentPlayer && board[2][i] == currentPlayer) return true
+        }
+        if (board[0][0] == currentPlayer && board[1][1] == currentPlayer && board[2][2] == currentPlayer) return true
+        if (board[0][2] == currentPlayer && board[1][1] == currentPlayer && board[2][0] == currentPlayer) return true
+        return false
+    }
+
+    private fun isBoardFull(): Boolean {
+        for (row in board) {
+            for (cell in row) if (cell.isEmpty()) return false
+        }
+        return true
+    }
+
+    private fun disableBoard() {
+        for (i in 0 until gridLayout.childCount) {
+            gridLayout.getChildAt(i).isEnabled = false
+        }
+    }
+
+    private fun updateStatus() {
+        statusText.text = getString(R.string.turn_text, currentPlayer)
+    }
+}
+

--- a/app/src/main/res/drawable/ic_games.xml
+++ b/app/src/main/res/drawable/ic_games.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M2,18l3-3h14l3,3v2H2v-2zm11-9h3v3h-3V9zm-5,0h3v3H8V9zM4,5h16v2H4V5z" />
+</vector>

--- a/app/src/main/res/drawable/ic_quiz.xml
+++ b/app/src/main/res/drawable/ic_quiz.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 17h-1v-1h1v1zm2.07-7.75l-.9.92C12.45 12.9 12 13.5 12 15h-1.5v-.5c0-1 .45-1.58 1.07-2.19l1.2-1.2c.37-.36.57-.86.57-1.39 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z" />
+</vector>

--- a/app/src/main/res/layout/activity_tap_game.xml
+++ b/app/src/main/res/layout/activity_tap_game.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/scoreText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="18sp"
+        android:layout_marginBottom="16dp" />
+
+    <Button
+        android:id="@+id/tapButton"
+        android:layout_width="200dp"
+        android:layout_height="wrap_content"
+        android:text="Tap" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_tic_tac_toe.xml
+++ b/app/src/main/res/layout/activity_tic_tac_toe.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/statusText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="18sp"
+        android:layout_marginBottom="16dp"/>
+
+    <GridLayout
+        android:id="@+id/gridLayout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:rowCount="3"
+        android:columnCount="3">
+
+        <Button
+            android:layout_width="80dp"
+            android:layout_height="80dp" />
+        <Button
+            android:layout_width="80dp"
+            android:layout_height="80dp" />
+        <Button
+            android:layout_width="80dp"
+            android:layout_height="80dp" />
+        <Button
+            android:layout_width="80dp"
+            android:layout_height="80dp" />
+        <Button
+            android:layout_width="80dp"
+            android:layout_height="80dp" />
+        <Button
+            android:layout_width="80dp"
+            android:layout_height="80dp" />
+        <Button
+            android:layout_width="80dp"
+            android:layout_height="80dp" />
+        <Button
+            android:layout_width="80dp"
+            android:layout_height="80dp" />
+        <Button
+            android:layout_width="80dp"
+            android:layout_height="80dp" />
+    </GridLayout>
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_games.xml
+++ b/app/src/main/res/layout/fragment_games.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <Button
+        android:id="@+id/btnTapGame"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Tap Game" />
+
+    <Button
+        android:id="@+id/btnTicTacToe"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Tic Tac Toe"
+        android:layout_marginTop="16dp" />
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_quiz.xml
+++ b/app/src/main/res/layout/fragment_quiz.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Who won the 2011 World Cup?"
+            android:textSize="18sp"
+            android:layout_marginBottom="8dp" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="A) India"
+            android:layout_marginBottom="4dp" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="B) Sri Lanka"
+            android:layout_marginBottom="4dp" />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="C) Australia"
+            android:layout_marginBottom="4dp" />
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -8,6 +8,14 @@
         android:icon="@drawable/ic_scores"
         android:title="Scores" />
     <item
+        android:id="@+id/nav_games"
+        android:icon="@drawable/ic_games"
+        android:title="Games" />
+    <item
+        android:id="@+id/nav_quiz"
+        android:icon="@drawable/ic_quiz"
+        android:title="Quiz" />
+    <item
         android:id="@+id/nav_profile"
         android:icon="@drawable/ic_profile"
         android:title="Profile" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,7 @@
 <resources>
     <string name="app_name">CricketVerse</string>
+<string name="turn_text">%1$s's turn</string>
+<string name="winner_text">%1$s wins!</string>
+<string name="draw_text">Draw!</string>
+<string name="score_value">Score: %1$d\nTime: %2$d</string>
 </resources>


### PR DESCRIPTION
## Summary
- add Games and Quiz fragments
- create simple mini-game activities: TapGame and TicTacToe
- hook new fragments into bottom navigation and manifest
- add menu icons and layouts
- add strings for mini-games

## Testing
- `./gradlew test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686319facd088320b35dc3449a0bf09d