### PR TITLE
Add offline score demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ The ultimate cricket experience:
 - Animated Player Profiles
 - Cricket-Themed Minigames
 - Quiz, News, Stats & More
+
+## Local Demo
+
+For offline testing, the app reads scores from `sample_scores.json` in the `assets` directory. This lets you see sample match data without a network connection.

--- a/app/src/main/assets/sample_scores.json
+++ b/app/src/main/assets/sample_scores.json
@@ -1,0 +1,27 @@
+{
+  "status": "success",
+  "data": [
+    {
+      "id": "1",
+      "name": "India vs Australia",
+      "status": "Live",
+      "venue": "Wankhede Stadium",
+      "date": "2025-07-01",
+      "teamName": "India",
+      "score": "150/3",
+      "overs": "20",
+      "wickets": "3"
+    },
+    {
+      "id": "2",
+      "name": "Pakistan vs England",
+      "status": "Upcoming",
+      "venue": "Lahore",
+      "date": "2025-07-02",
+      "teamName": "Pakistan",
+      "score": "0/0",
+      "overs": "0",
+      "wickets": "0"
+    }
+  ]
+}

--- a/app/src/main/java/com/motus/cricketverse/ScoreFragment.kt
+++ b/app/src/main/java/com/motus/cricketverse/ScoreFragment.kt
@@ -4,81 +4,81 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
-import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
-import android.widget.Toast
-import com.motus.cricketverse.adapter.ScoreAdapter
-import com.motus.cricketverse.model.LiveScore
-import com.motus.cricketverse.network.CricApiService
-import com.motus.cricketverse.repository.MatchRepository
-import com.motus.cricketverse.network.RetrofitClient
-import com.motus.cricketverse.viewmodel.ScoreViewModel
 import android.view.animation.AnimationUtils
+import android.widget.Toast
+import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.gson.Gson
+import com.google.gson.reflect.TypeToken
+import com.motus.cricketverse.adapter.ScoreAdapter
+import com.motus.cricketverse.model.ScoreItem
+import java.io.BufferedReader
+import java.io.InputStreamReader
+
 class ScoreFragment : Fragment() {
-    private lateinit var scoreViewModel: ScoreViewModel
+
     private lateinit var scoreAdapter: ScoreAdapter
-    private lateinit var viewModel: ScoreViewModel
-    private lateinit var scoreTextView: TextView
 
     override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
+        inflater: LayoutInflater,
+        container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        val view = inflater.inflate(R.layout.fragment_scores, container, false)
-        scoreTextView = view.findViewById(R.id.tvLiveScore)
-        return view
+        return inflater.inflate(R.layout.fragment_scores, container, false)
     }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // Animation
         val animation = AnimationUtils.loadAnimation(requireContext(), R.anim.fade_in)
         view.startAnimation(animation)
 
-        // RecyclerView setup
         scoreAdapter = ScoreAdapter()
         val recyclerView = view.findViewById<RecyclerView>(R.id.recyclerView)
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = scoreAdapter
 
-        // Setup API & Repository
-        val apiService = RetrofitClient.getRetrofitInstance().create(CricApiService::class.java)
-        val repository = MatchRepository(apiService)
-
-        // ViewModel setup
-        viewModel = ViewModelProvider(this, object : ViewModelProvider.Factory {
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                return ScoreViewModel(repository) as T
-            }
-        })[ScoreViewModel::class.java]
-
-        // Observe Live Score
-        viewModel.liveScore.observe(viewLifecycleOwner) { liveScore ->
-            liveScore?.let {
-                updateUI(it)
-            }
-        }
-
-        // Observe Errors
-        viewModel.error.observe(viewLifecycleOwner) { errorMsg ->
-            Toast.makeText(requireContext(), errorMsg, Toast.LENGTH_SHORT).show()
-        }
-
-        // Fetch Score (use your actual API key)
-        viewModel.fetchLiveScore(apiKey = "a603d924-a1b3-4c3b-98fa-37a320bf4596")
+        loadLocalScores()
     }
 
-    private fun updateUI(score: LiveScore) {
-        data class LiveScore(
-            val id: String?,
-            val name: String?,
-            val status: String?,
-            val venue: String?,
-            val date: String?
-        )
+    private fun loadLocalScores() {
+        try {
+            val inputStream = requireContext().assets.open("sample_scores.json")
+            val reader = BufferedReader(InputStreamReader(inputStream))
+            val json = reader.readText()
+            reader.close()
+
+            val type = object : TypeToken<SampleScoreResponse>() {}.type
+            val response: SampleScoreResponse = Gson().fromJson(json, type)
+            val items = response.data.map {
+                ScoreItem(
+                    teamName = it.teamName,
+                    score = it.score,
+                    overs = it.overs,
+                    wickets = it.wickets,
+                    status = it.status
+                )
+            }
+            scoreAdapter.submitList(items)
+        } catch (e: Exception) {
+            Toast.makeText(requireContext(), "Failed to load scores", Toast.LENGTH_SHORT).show()
+        }
     }
+
+    data class SampleScoreResponse(
+        val data: List<LocalScore>
+    )
+
+    data class LocalScore(
+        val id: String,
+        val name: String,
+        val status: String,
+        val venue: String,
+        val date: String,
+        val teamName: String,
+        val score: String,
+        val overs: String,
+        val wickets: String
+    )
 }

--- a/app/src/main/java/com/motus/cricketverse/adapter/ScoreAdapter.kt
+++ b/app/src/main/java/com/motus/cricketverse/adapter/ScoreAdapter.kt
@@ -33,10 +33,16 @@ class ScoreAdapter : RecyclerView.Adapter<ScoreAdapter.ScoreViewHolder>() {
     class ScoreViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val teamName: TextView = itemView.findViewById(R.id.teamNameTextView)
         private val score: TextView = itemView.findViewById(R.id.scoreTextView)
+        private val overs: TextView = itemView.findViewById(R.id.oversTextView)
+        private val wickets: TextView = itemView.findViewById(R.id.wicketsTextView)
+        private val status: TextView = itemView.findViewById(R.id.statusTextView)
 
         fun bind(item: ScoreItem) {
             teamName.text = item.teamName
             score.text = item.score
+            overs.text = "Overs: ${item.overs}"
+            wickets.text = "Wickets: ${item.wickets}"
+            status.text = item.status
         }
     }
 }

--- a/app/src/main/java/com/motus/cricketverse/model/LiveScore.kt
+++ b/app/src/main/java/com/motus/cricketverse/model/LiveScore.kt
@@ -4,6 +4,8 @@ data class LiveScore(
     val id: String?,
     val teamName: String,
     val score: String,
+    val overs: String,
+    val wickets: String,
     val name: String?,
     val status: String?,
     val venue: String?,

--- a/app/src/main/java/com/motus/cricketverse/model/ScoreItem.kt
+++ b/app/src/main/java/com/motus/cricketverse/model/ScoreItem.kt
@@ -3,4 +3,7 @@ package com.motus.cricketverse.model
 data class ScoreItem(
     val teamName: String,
     val score: String,
+    val overs: String,
+    val wickets: String,
+    val status: String,
 )

--- a/app/src/main/res/layout/item_score.xml
+++ b/app/src/main/res/layout/item_score.xml
@@ -1,34 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:orientation="vertical"
     android:padding="12dp">
 
-    <TextView
-        android:id="@+id/teamNameTextView"
-        android:layout_width="0dp"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Team A"
-        android:textStyle="bold"
-        android:textSize="18sp"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/scoreTextView"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintHorizontal_weight="1" />
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/teamNameTextView"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="Team A"
+            android:textStyle="bold"
+            android:textSize="18sp" />
+
+        <TextView
+            android:id="@+id/scoreTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="120/3"
+            android:textSize="16sp" />
+    </LinearLayout>
 
     <TextView
-        android:id="@+id/scoreTextView"
+        android:id="@+id/oversTextView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="120/3"
-        android:textSize="16sp"
-        android:textColor="#333333"
-        android:textStyle="normal"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintBottom_toBottomOf="parent" />
+        android:text="Overs: 0"
+        android:textSize="14sp" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <TextView
+        android:id="@+id/wicketsTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Wickets: 0"
+        android:textSize="14sp" />
+
+    <TextView
+        android:id="@+id/statusTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Live"
+        android:textStyle="italic"
+        android:textSize="14sp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add offline scores JSON under assets
- show scores in ScoreFragment using local data
- display overs/wickets/status in item view
- document offline demo usage

## Testing
- `./gradlew assembleDebug` *(fails: Permission denied or missing wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_68631df5620c832081e27ec3c61c28bc