### PR TITLE
Add new modules and bottom navigation update

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,6 +15,8 @@ android {
         versionCode 1
         versionName "1.0"
 
+        buildConfigField "String", "YOUTUBE_API_KEY", '"REPLACE_WITH_KEY"'
+
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -52,6 +54,9 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
     // Physics-based animations
     implementation 'androidx.dynamicanimation:dynamicanimation:1.1.0'
+    // Loading shimmer effect
+    implementation 'com.facebook.shimmer:shimmer:0.5.0'
+    implementation 'com.github.bumptech.glide:glide:4.16.0'
 
     // Testing
     testImplementation 'junit:junit:4.13.2'

--- a/app/src/main/java/com/motus/cricketverse/AnalyticsFragment.kt
+++ b/app/src/main/java/com/motus/cricketverse/AnalyticsFragment.kt
@@ -1,0 +1,17 @@
+package com.motus.cricketverse
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class AnalyticsFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_analytics, container, false)
+    }
+}

--- a/app/src/main/java/com/motus/cricketverse/MainActivity.kt
+++ b/app/src/main/java/com/motus/cricketverse/MainActivity.kt
@@ -5,8 +5,13 @@ import androidx.fragment.app.Fragment
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.motus.cricketverse.ScoreFragment
 import com.motus.cricketverse.GamesFragment
+import com.motus.cricketverse.MapFragment
+import com.motus.cricketverse.AnalyticsFragment
 import com.motus.cricketverse.ui.HomeFragment
 import com.motus.cricketverse.ui.QuizFragment
+import com.motus.cricketverse.ui.youtube.YouTubeFragment
+import com.motus.cricketverse.ui.kismet.KismetFragment
+import com.motus.cricketverse.ui.fantasy.FantasyFragment
 class MainActivity : AppCompatActivity() {
 
     private lateinit var bottomNavigationView: BottomNavigationView
@@ -22,11 +27,14 @@ class MainActivity : AppCompatActivity() {
         bottomNavigationView.setOnItemSelectedListener { item ->
             val fragment: Fragment = when (item.itemId) {
                 R.id.nav_home -> HomeFragment()
-                R.id.nav_matches -> MatchesFragment()
                 R.id.nav_scores -> ScoreFragment()
-                R.id.nav_games -> GamesFragment()
+                R.id.nav_map -> MapFragment()
                 R.id.nav_quiz -> QuizFragment()
-                R.id.nav_profile -> ProfileFragment()
+                R.id.nav_games -> GamesFragment()
+                R.id.nav_analytics -> AnalyticsFragment()
+                R.id.nav_youtube -> YouTubeFragment()
+                R.id.nav_kismet -> KismetFragment()
+                R.id.nav_fantasy -> FantasyFragment()
                 else -> HomeFragment()
             }
             loadFragment(fragment)

--- a/app/src/main/java/com/motus/cricketverse/MapFragment.kt
+++ b/app/src/main/java/com/motus/cricketverse/MapFragment.kt
@@ -1,0 +1,17 @@
+package com.motus.cricketverse
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+
+class MapFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_map, container, false)
+    }
+}

--- a/app/src/main/java/com/motus/cricketverse/core/HealthCheck.kt
+++ b/app/src/main/java/com/motus/cricketverse/core/HealthCheck.kt
@@ -1,0 +1,26 @@
+package com.motus.cricketverse.core
+
+import android.content.Context
+import android.util.Log
+import com.motus.cricketverse.R
+
+object HealthCheck {
+    fun run(context: Context) {
+        val tag = "CricketVerse-Debug"
+        val routes = listOf(
+            R.id.nav_home to R.layout.fragment_home,
+            R.id.nav_scores to R.layout.fragment_scores,
+            R.id.nav_youtube to R.layout.fragment_youtube,
+            R.id.nav_kismet to R.layout.fragment_kismet,
+            R.id.nav_fantasy to R.layout.fragment_fantasy
+        )
+        routes.forEach { (menuId, layout) ->
+            try {
+                context.resources.getResourceName(menuId)
+                context.resources.getResourceName(layout)
+            } catch (e: Exception) {
+                Log.d(tag, "Missing reference: ${e.message}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/motus/cricketverse/ui/fantasy/FantasyFragment.kt
+++ b/app/src/main/java/com/motus/cricketverse/ui/fantasy/FantasyFragment.kt
@@ -1,0 +1,60 @@
+package com.motus.cricketverse.ui.fantasy
+
+import android.content.Context
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.motus.cricketverse.R
+
+class FantasyFragment : Fragment() {
+
+    private lateinit var winnerField: EditText
+    private lateinit var batsmanField: EditText
+    private lateinit var bowlerField: EditText
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_fantasy, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        winnerField = view.findViewById(R.id.winnerField)
+        batsmanField = view.findViewById(R.id.batsmanField)
+        bowlerField = view.findViewById(R.id.bowlerField)
+
+        view.findViewById<Button>(R.id.saveButton).setOnClickListener { savePredictions() }
+        view.findViewById<Button>(R.id.editButton).setOnClickListener { loadPredictions() }
+    }
+
+    private fun prefs() = requireContext().getSharedPreferences("predictions", Context.MODE_PRIVATE)
+
+    private fun savePredictions() {
+        val model = PredictionModel(
+            winnerField.text.toString(),
+            batsmanField.text.toString(),
+            bowlerField.text.toString()
+        )
+        prefs().edit().apply {
+            putString("winner", model.matchWinner)
+            putString("batsman", model.topBatsman)
+            putString("bowler", model.topBowler)
+            apply()
+        }
+        Toast.makeText(requireContext(), "Prediction Saved", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun loadPredictions() {
+        winnerField.setText(prefs().getString("winner", ""))
+        batsmanField.setText(prefs().getString("batsman", ""))
+        bowlerField.setText(prefs().getString("bowler", ""))
+    }
+}

--- a/app/src/main/java/com/motus/cricketverse/ui/fantasy/PredictionModel.kt
+++ b/app/src/main/java/com/motus/cricketverse/ui/fantasy/PredictionModel.kt
@@ -1,0 +1,8 @@
+package com.motus.cricketverse.ui.fantasy
+
+/** Offline prediction model */
+data class PredictionModel(
+    val matchWinner: String,
+    val topBatsman: String,
+    val topBowler: String
+)

--- a/app/src/main/java/com/motus/cricketverse/ui/kismet/KismetFragment.kt
+++ b/app/src/main/java/com/motus/cricketverse/ui/kismet/KismetFragment.kt
@@ -1,0 +1,56 @@
+package com.motus.cricketverse.ui.kismet
+
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.animation.AlphaAnimation
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import com.motus.cricketverse.R
+
+class KismetFragment : Fragment() {
+
+    private val tips = listOf(
+        "Consistency beats talent.",
+        "Don’t chase the ball, chase the moment.",
+        "Train like you play."
+    )
+    private lateinit var quoteView: TextView
+    private var tipIndex = 0
+    private val handler = Handler(Looper.getMainLooper())
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_kismet, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        quoteView = view.findViewById(R.id.kismetQuote)
+        view.findViewById<Button>(R.id.askButton).setOnClickListener {
+            Toast.makeText(requireContext(), "Coming soon.", Toast.LENGTH_SHORT).show()
+        }
+        rotateQuotes()
+    }
+
+    private fun rotateQuotes() {
+        quoteView.text = tips[tipIndex]
+        val fadeIn = AlphaAnimation(0f, 1f).apply { duration = 800 }
+        val fadeOut = AlphaAnimation(1f, 0f).apply { duration = 800 }
+        quoteView.startAnimation(fadeIn)
+        handler.postDelayed({
+            quoteView.startAnimation(fadeOut)
+            tipIndex = (tipIndex + 1) % tips.size
+            handler.postDelayed({ rotateQuotes() }, 800)
+        }, 3000)
+    }
+}

--- a/app/src/main/java/com/motus/cricketverse/ui/youtube/YouTubeAdapter.kt
+++ b/app/src/main/java/com/motus/cricketverse/ui/youtube/YouTubeAdapter.kt
@@ -1,0 +1,47 @@
+package com.motus.cricketverse.ui.youtube
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.motus.cricketverse.R
+
+class YouTubeAdapter(
+    private var videos: List<YouTubeVideo>,
+    private val onClick: (YouTubeVideo) -> Unit
+) : RecyclerView.Adapter<YouTubeAdapter.VideoViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VideoViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_youtube_video, parent, false)
+        return VideoViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: VideoViewHolder, position: Int) {
+        val video = videos[position]
+        holder.bind(video)
+        holder.itemView.setOnClickListener { onClick(video) }
+    }
+
+    override fun getItemCount(): Int = videos.size
+
+    fun update(list: List<YouTubeVideo>) {
+        videos = list
+        notifyDataSetChanged()
+    }
+
+    class VideoViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        private val title: TextView = itemView.findViewById(R.id.titleTextView)
+        private val channel: TextView = itemView.findViewById(R.id.channelTextView)
+        private val thumb: ImageView = itemView.findViewById(R.id.thumbnailImageView)
+
+        fun bind(video: YouTubeVideo) {
+            title.text = video.title
+            channel.text = video.channelName
+            Glide.with(itemView).load(video.thumbnailUrl).into(thumb)
+        }
+    }
+}

--- a/app/src/main/java/com/motus/cricketverse/ui/youtube/YouTubeFragment.kt
+++ b/app/src/main/java/com/motus/cricketverse/ui/youtube/YouTubeFragment.kt
@@ -1,0 +1,102 @@
+package com.motus.cricketverse.ui.youtube
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.facebook.shimmer.ShimmerFrameLayout
+import com.motus.cricketverse.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+class YouTubeFragment : Fragment() {
+
+    private lateinit var adapter: YouTubeAdapter
+    private lateinit var shimmer: ShimmerFrameLayout
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_youtube, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        shimmer = view.findViewById(R.id.shimmerLayout)
+        val recycler = view.findViewById<androidx.recyclerview.widget.RecyclerView>(R.id.videoRecyclerView)
+        recycler.layoutManager = LinearLayoutManager(requireContext())
+        adapter = YouTubeAdapter(emptyList()) { openVideo(it.videoId) }
+        recycler.adapter = adapter
+        fetchVideos()
+    }
+
+    private fun openVideo(videoId: String) {
+        val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://www.youtube.com/watch?v=$videoId"))
+        startActivity(intent)
+    }
+
+    private fun fetchVideos() {
+        shimmer.startShimmer()
+        lifecycleScope.launch {
+            val service = Retrofit.Builder()
+                .baseUrl("https://www.googleapis.com/youtube/v3/")
+                .addConverterFactory(GsonConverterFactory.create())
+                .build()
+                .create(YouTubeService::class.java)
+            val response = withContext(Dispatchers.IO) {
+                service.searchVideos(
+                    query = "latest cricket highlights",
+                    maxResults = 10,
+                    apiKey = BuildConfig.YOUTUBE_API_KEY
+                )
+            }
+            val videos = response.items.map {
+                YouTubeVideo(
+                    title = it.snippet.title,
+                    thumbnailUrl = it.snippet.thumbnails.medium.url,
+                    videoId = it.id.videoId,
+                    channelName = it.snippet.channelTitle
+                )
+            }
+            adapter.update(videos)
+            shimmer.stopShimmer()
+            shimmer.visibility = View.GONE
+        }
+    }
+
+    interface YouTubeService {
+        @GET("search")
+        suspend fun searchVideos(
+            @Query("part") part: String = "snippet",
+            @Query("q") query: String,
+            @Query("type") type: String = "video",
+            @Query("maxResults") maxResults: Int,
+            @Query("order") order: String = "date",
+            @Query("key") apiKey: String
+        ): YouTubeResponse
+    }
+
+    data class YouTubeResponse(val items: List<Item>) {
+        data class Item(val id: Id, val snippet: Snippet)
+        data class Id(val videoId: String)
+        data class Snippet(
+            val title: String,
+            val channelTitle: String,
+            val thumbnails: Thumbnails
+        )
+        data class Thumbnails(val medium: Thumbnail)
+        data class Thumbnail(val url: String)
+    }
+}

--- a/app/src/main/java/com/motus/cricketverse/ui/youtube/YouTubeVideo.kt
+++ b/app/src/main/java/com/motus/cricketverse/ui/youtube/YouTubeVideo.kt
@@ -1,0 +1,9 @@
+package com.motus.cricketverse.ui.youtube
+
+/** Simple model for YouTube search result */
+data class YouTubeVideo(
+    val title: String,
+    val thumbnailUrl: String,
+    val videoId: String,
+    val channelName: String
+)

--- a/app/src/main/java/com/motus/cricketverse/utils/PermissionUtils.kt
+++ b/app/src/main/java/com/motus/cricketverse/utils/PermissionUtils.kt
@@ -1,0 +1,38 @@
+package com.motus.cricketverse.utils
+
+import android.app.Activity
+import android.content.pm.PackageManager
+import androidx.appcompat.app.AlertDialog
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+
+object PermissionUtils {
+    fun requestPermission(activity: Activity, permission: String, code: Int, onGranted: () -> Unit = {}) {
+        if (ContextCompat.checkSelfPermission(activity, permission) == PackageManager.PERMISSION_GRANTED) {
+            onGranted()
+        } else {
+            if (ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
+                AlertDialog.Builder(activity)
+                    .setMessage("Permission required for full functionality")
+                    .setPositiveButton("OK") { _, _ ->
+                        ActivityCompat.requestPermissions(activity, arrayOf(permission), code)
+                    }
+                    .setNegativeButton("Cancel", null)
+                    .show()
+            } else {
+                ActivityCompat.requestPermissions(activity, arrayOf(permission), code)
+            }
+        }
+    }
+
+    fun handleResult(activity: Activity, requestCode: Int, grantResults: IntArray, expectedCode: Int, onGranted: () -> Unit = {}) {
+        if (requestCode == expectedCode && grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+            onGranted()
+        } else if (requestCode == expectedCode) {
+            AlertDialog.Builder(activity)
+                .setMessage("Permission denied")
+                .setPositiveButton("OK", null)
+                .show()
+        }
+    }
+}

--- a/app/src/main/res/layout/fragment_analytics.xml
+++ b/app/src/main/res/layout/fragment_analytics.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Stats Coming Soon" />
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_fantasy.xml
+++ b/app/src/main/res/layout/fragment_fantasy.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingTop="24dp"
+    android:paddingBottom="16dp"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Team A vs Team B"
+        android:textSize="22sp"
+        android:textStyle="bold" />
+
+    <EditText
+        android:id="@+id/winnerField"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Match Winner" />
+
+    <EditText
+        android:id="@+id/batsmanField"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Top Batsman" />
+
+    <EditText
+        android:id="@+id/bowlerField"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:hint="Top Bowler" />
+
+    <Button
+        android:id="@+id/saveButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Save Prediction" />
+
+    <Button
+        android:id="@+id/editButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="Edit Prediction" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_kismet.xml
+++ b/app/src/main/res/layout/fragment_kismet.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:paddingTop="24dp"
+    android:paddingBottom="16dp"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp">
+
+    <TextView
+        android:id="@+id/kismetAvatar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="👩‍💻"
+        android:textSize="64sp" />
+
+    <TextView
+        android:id="@+id/kismetQuote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="" />
+
+    <TextView
+        android:id="@+id/kismetStatus"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Kismet is listening... Coming soon." />
+
+    <Button
+        android:id="@+id/askButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Ask Kismet (Beta)" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_map.xml
+++ b/app/src/main/res/layout/fragment_map.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Map Coming Soon" />
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_youtube.xml
+++ b/app/src/main/res/layout/fragment_youtube.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="24dp"
+    android:paddingBottom="16dp"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp">
+
+    <com.facebook.shimmer.ShimmerFrameLayout
+        android:id="@+id/shimmerLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:shimmer_auto_start="true">
+
+        <RecyclerView
+            android:id="@+id/videoRecyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </com.facebook.shimmer.ShimmerFrameLayout>
+
+</FrameLayout>

--- a/app/src/main/res/layout/item_youtube_video.xml
+++ b/app/src/main/res/layout/item_youtube_video.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    android:elevation="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="12dp">
+
+        <ImageView
+            android:id="@+id/thumbnailImageView"
+            android:layout_width="match_parent"
+            android:layout_height="180dp"
+            android:scaleType="centerCrop" />
+
+        <TextView
+            android:id="@+id/titleTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textStyle="bold"
+            android:textSize="16sp" />
+
+        <TextView
+            android:id="@+id/channelTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="14sp" />
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,23 +1,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:id="@+id/nav_home" android:icon="@drawable/ic_home" android:title="Home" />
-    <item
-        android:id="@+id/nav_matches"
-        android:icon="@drawable/ic_matches"
-        android:title="Matches" />
-    <item
-        android:id="@+id/nav_scores"
-        android:icon="@drawable/ic_scores"
-        android:title="Scores" />
-    <item
-        android:id="@+id/nav_games"
-        android:icon="@drawable/ic_games"
-        android:title="Games" />
-    <item
-        android:id="@+id/nav_quiz"
-        android:icon="@drawable/ic_quiz"
-        android:title="Quiz" />
-    <item
-        android:id="@+id/nav_profile"
-        android:icon="@drawable/ic_profile"
-        android:title="Profile" />
+    <item android:id="@+id/nav_scores" android:icon="@drawable/ic_scores" android:title="Scores" />
+    <item android:id="@+id/nav_map" android:icon="@drawable/ic_home" android:title="Map" />
+    <item android:id="@+id/nav_quiz" android:icon="@drawable/ic_quiz" android:title="Quiz" />
+    <item android:id="@+id/nav_games" android:icon="@drawable/ic_games" android:title="Games" />
+    <item android:id="@+id/nav_analytics" android:icon="@drawable/ic_matches" android:title="Stats" />
+    <item android:id="@+id/nav_youtube" android:icon="@drawable/ic_games" android:title="Videos" />
+    <item android:id="@+id/nav_kismet" android:icon="@drawable/ic_profile" android:title="Kismet" />
+    <item android:id="@+id/nav_fantasy" android:icon="@drawable/ic_scores" android:title="Fantasy" />
 </menu>


### PR DESCRIPTION
## Summary
- implement YouTube highlights fragment with Retrofit and shimmer loading
- add Kismet placeholder with rotating tips
- create Fantasy prediction module storing to SharedPrefs
- introduce generic permission helper and runtime health check
- add placeholder map and analytics fragments
- update bottom navigation and MainActivity routing

## Testing
- `./gradlew test` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_686340f174708320beaa30d164a9f48e