### PR TITLE
Update compileSdk and targetSdk to 35

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,12 +6,12 @@ plugins {
 
 android {
     namespace 'com.motus.cricketverse'
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         applicationId "com.motus.cricketverse"
         minSdk 24
-        targetSdk 34
+        targetSdk 35
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
## Summary
- bump `compileSdk` and `targetSdk` from 34 to 35 in the app module

## Testing
- `gradle assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634d4854808320a2e02058630e8b93