### PR TITLE
Fix resource build error

### DIFF
--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -99,7 +99,7 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="News & Stats"
+            android:text="News &amp; Stats"
             android:textStyle="bold"
             android:textSize="20sp"
             android:layout_marginTop="16dp" />


### PR DESCRIPTION
## Summary
- fix invalid `&` in fragment_home layout

## Testing
- `xmllint --noout app/src/main/res/layout/fragment_home.xml`
- `find app/src/main/res -name '*.xml' | while read f; do xmllint --noout "$f"; done`
- `gradle --no-daemon assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68634f8155c483209b6ea23bd37921da